### PR TITLE
make Map Clone

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,7 +203,7 @@ extern "C" {
 
     // Map
 
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub type Map;
 
     #[wasm_bindgen(constructor, js_namespace = L)]


### PR DESCRIPTION
I'm trying to use leaflet-rs with [leptos](https://www.leptos.dev/), and I need `Map` to be `Clone` in order to make it work within leptos' signal system. 