### PR TITLE
Upgrade yew to 0.21 in yew example

### DIFF
--- a/examples/yew-component/Cargo.toml
+++ b/examples/yew-component/Cargo.toml
@@ -10,7 +10,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-yew = "0.19"
+yew = { version = "0.21.0", features = ["csr"] }
+implicit-clone = "0.3.6"
 leaflet = "0.2"
 wasm-bindgen = "0.2"
 gloo-console = "0.2"

--- a/examples/yew-component/src/components/control.rs
+++ b/examples/yew-component/src/components/control.rs
@@ -53,10 +53,6 @@ impl Component for Control {
         true
     }
 
-    fn changed(&mut self, _ctx: &Context<Self>) -> bool {
-        false
-    }
-
     fn view(&self, ctx: &Context<Self>) -> Html {
         html! {
             <div class="control component-container">

--- a/examples/yew-component/src/components/map_component.rs
+++ b/examples/yew-component/src/components/map_component.rs
@@ -64,7 +64,7 @@ impl Component for MapComponent {
         false
     }
 
-    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+    fn changed(&mut self, ctx: &Context<Self>, _old_props: &Self::Properties) -> bool {
         let props = ctx.props();
 
         if self.lat == props.city.lat {

--- a/examples/yew-component/src/main.rs
+++ b/examples/yew-component/src/main.rs
@@ -49,10 +49,6 @@ impl Component for Model {
         true
     }
 
-    fn changed(&mut self, _ctx: &Context<Self>) -> bool {
-        false
-    }
-
     fn view(&self, ctx: &Context<Self>) -> Html {
         let cb = ctx.link().callback(Msg::SelectCity);
         html! {
@@ -65,5 +61,5 @@ impl Component for Model {
 }
 
 fn main() {
-    yew::start_app::<Model>();
+    yew::Renderer::<Model>::new().render();
 }


### PR DESCRIPTION
This merge request upgrades yew in the yew example to version 0.21.
Dependency implicit-clone had to be added to fix a compile error.
