### PR TITLE
Refactor of macros, added TileLayerWms::get_feature_info_url

### DIFF
--- a/src/control.rs
+++ b/src/control.rs
@@ -1,6 +1,6 @@
 mod zoom;
 
-use crate::{object_constructor, object_property_set, Map};
+use crate::{create_object_with_properties, Map};
 use js_sys::Object;
 use wasm_bindgen::prelude::*;
 use web_sys::HtmlElement;
@@ -9,10 +9,6 @@ pub use zoom::{Zoom, ZoomOptions};
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(extends = Object , js_name = ControlOptions)]
-    #[derive(Debug, Clone, PartialEq, Eq)]
-    pub type ControlOptions;
-
     #[derive(Clone, Debug)]
     #[wasm_bindgen(js_namespace = L, js_name = Control)]
     pub type Control;
@@ -36,12 +32,10 @@ extern "C" {
     pub fn remove(this: &Control) -> Control;
 }
 
-impl ControlOptions {
-    object_constructor!();
-
-    // ControlOptions
-    object_property_set!(position, position, &str);
-}
+create_object_with_properties!(
+    (ControlOptions, ControlOptions),
+    (position, position, String)
+);
 
 impl Default for ControlOptions {
     fn default() -> Self {

--- a/src/div_icon.rs
+++ b/src/div_icon.rs
@@ -1,13 +1,9 @@
-use crate::{object_constructor, object_property_set, Icon, Point};
+use crate::{create_object_with_properties, Icon, Point};
 use js_sys::Object;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(extends = Object, js_name = DivIconOptions)]
-    #[derive(Debug, Clone)]
-    pub type DivIconOptions;
-
     #[derive(Debug, Clone)]
     #[wasm_bindgen(extends = Icon, js_namespace = L, js_name = Icon)]
     pub type DivIcon;
@@ -16,17 +12,17 @@ extern "C" {
     pub fn new(options: &DivIconOptions) -> DivIcon;
 }
 
-impl DivIconOptions {
-    object_constructor!();
-    object_property_set!(html, &str);
-    object_property_set!(bg_pos, bgPos, Point);
-    object_property_set!(icon_size, iconSize, Point);
-    object_property_set!(icon_anchor, iconAnchor, Point);
-    object_property_set!(popup_anchor, popupAnchor, Point);
-    object_property_set!(tooltip_anchor, tooltipAnchor, Point);
-    object_property_set!(class_name, className, &str);
-    object_property_set!(cross_origin, crossOrigin, &str);
-}
+create_object_with_properties!(
+    (DivIconOptions, DivIconOptions),
+    (html, html, String),
+    (bg_pos, bgPos, Point),
+    (icon_size, iconSize, Point),
+    (icon_anchor, iconAnchor, Point),
+    (popup_anchor, popupAnchor, Point),
+    (tooltip_anchor, tooltipAnchor, Point),
+    (class_name, className, String),
+    (cross_origin, crossOrigin, String)
+);
 
 impl Default for DivIconOptions {
     fn default() -> Self {

--- a/src/grid_layer.rs
+++ b/src/grid_layer.rs
@@ -2,14 +2,10 @@ use js_sys::Object;
 use wasm_bindgen::prelude::*;
 use web_sys::HtmlElement;
 
-use crate::{object_constructor, object_property_set, LatLngBounds, Layer, Point};
+use crate::{create_object_with_properties, LatLngBounds, Layer, LayerOptions, Point};
 
 #[wasm_bindgen]
 extern "C" {
-
-    # [wasm_bindgen (extends = Object, js_name = GridLayerOptions)]
-    #[derive(Debug, Clone, PartialEq)]
-    pub type GridLayerOptions;
 
     #[wasm_bindgen(extends = Layer)]
     #[derive(Debug, Clone, PartialEq)]
@@ -43,25 +39,25 @@ extern "C" {
     pub fn redraw(this: &GridLayer) -> GridLayer;
 }
 
-impl GridLayerOptions {
-    object_constructor!();
-    object_property_set!(tile_size, tileSize, f64);
-    object_property_set!(tile_size_point, tileSize, &Point);
-    object_property_set!(opacity, f64);
-    object_property_set!(update_when_idle, updateWhenIdle, bool);
-    object_property_set!(update_when_zooming, updateWhenZooming, bool);
-    object_property_set!(update_interval, updateInterval, f64);
-    object_property_set!(z_index, zIndex, f64);
-    object_property_set!(bounds, &LatLngBounds);
-    object_property_set!(min_zoom, minZoom, f64);
-    object_property_set!(max_zoom, maxZoom, f64);
-    object_property_set!(min_native_zoom, minNativeZoom, f64);
-    object_property_set!(max_native_zoom, maxNativeZoom, f64);
-    object_property_set!(no_wrap, noWrap, bool);
-    object_property_set!(pane, &str);
-    object_property_set!(class_name, className, &str);
-    object_property_set!(keep_buffer, keepBuffer, f64);
-}
+create_object_with_properties!(
+    (GridLayerOptions, GridLayerOptions, LayerOptions),
+    (tile_size, tileSize, f64),
+    (tile_size_point, tileSize, Point),
+    (opacity, opacity, f64),
+    (update_when_idle, updateWhenIdle, bool),
+    (update_when_zooming, updateWhenZooming, bool),
+    (update_interval, updateInterval, f64),
+    (z_index, zIndex, f64),
+    (bounds, bounds, LatLngBounds),
+    (min_zoom, minZoom, f64),
+    (max_zoom, maxZoom, f64),
+    (min_native_zoom, minNativeZoom, f64),
+    (max_native_zoom, maxNativeZoom, f64),
+    (no_wrap, noWrap, bool),
+    (pane, pane, String),
+    (class_name, className, String),
+    (keep_buffer, keepBuffer, f64)
+);
 
 impl Default for GridLayerOptions {
     fn default() -> Self {

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -1,13 +1,9 @@
-use crate::{object_constructor, object_property_set, Point};
+use crate::{create_object_with_properties, Point};
 use js_sys::Object;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(extends = Object, js_name = IconOptions)]
-    #[derive(Debug, Clone)]
-    pub type IconOptions;
-
     #[derive(Debug, Clone)]
     #[wasm_bindgen(js_namespace = L, js_name = Icon)]
     pub type Icon;
@@ -16,20 +12,20 @@ extern "C" {
     pub fn new(options: &IconOptions) -> Icon;
 }
 
-impl IconOptions {
-    object_constructor!();
-    object_property_set!(icon_url, iconUrl, &str);
-    object_property_set!(icon_size, iconSize, Point);
-    object_property_set!(icon_anchor, iconAnchor, Point);
-    object_property_set!(popup_anchor, popupAnchor, Point);
-    object_property_set!(shadow_anchor, shadowAnchor, Point);
-    object_property_set!(tooltip_anchor, tooltipAnchor, Point);
-    object_property_set!(shadow_url, shadowUrl, &str);
-    object_property_set!(shadow_retina_url, shadowRetinaUrl, &str);
-    object_property_set!(shadow_size, shadowSize, Point);
-    object_property_set!(class_name, className, &str);
-    object_property_set!(cross_origin, crossOrigin, &str);
-}
+create_object_with_properties!(
+    (IconOptions, IconOptions),
+    (icon_url, iconUrl, String),
+    (icon_size, iconSize, Point),
+    (icon_anchor, iconAnchor, Point),
+    (popup_anchor, popupAnchor, Point),
+    (shadow_anchor, shadowAnchor, Point),
+    (tooltip_anchor, tooltipAnchor, Point),
+    (shadow_url, shadowUrl, String),
+    (shadow_retina_url, shadowRetinaUrl, String),
+    (shadow_size, shadowSize, Point),
+    (class_name, className, String),
+    (cross_origin, crossOrigin, String)
+);
 
 impl Default for IconOptions {
     fn default() -> Self {

--- a/src/lat_lng_bounds.rs
+++ b/src/lat_lng_bounds.rs
@@ -18,6 +18,9 @@ extern "C" {
 
     #[wasm_bindgen(method)]
     pub fn contains(this: &LatLngBounds, latlng: &LatLng) -> bool;
+
+    #[wasm_bindgen(method, js_name = toBBoxString)]
+    pub fn to_bbox_string(this: &LatLngBounds) -> String;
 }
 
 impl From<(LatLng, LatLng)> for LatLngBounds {

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -3,16 +3,10 @@ use wasm_bindgen::prelude::*;
 use web_sys::HtmlElement;
 
 use crate::evented::{LayerEvents, LeafletEventHandler, PopupEvents, TooltipEvents};
-use crate::{
-    object_constructor, object_property_set, Evented, LatLng, LayerGroup, Map, Popup, Tooltip,
-};
+use crate::{create_object_with_properties, Evented, LatLng, LayerGroup, Map, Popup, Tooltip};
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(extends = Object, js_name = LayerOptions)]
-    #[derive(Debug, Clone, PartialEq)]
-    pub type LayerOptions;
-
     #[wasm_bindgen(extends = Evented)]
     #[derive(Debug, Clone, PartialEq)]
     pub type Layer;
@@ -120,11 +114,11 @@ extern "C" {
     pub fn get_tooltip(this: &Layer) -> Tooltip;
 }
 
-impl LayerOptions {
-    object_constructor!();
-    object_property_set!(pane, &str);
-    object_property_set!(attribution, &str);
-}
+create_object_with_properties!(
+    (LayerOptions, LayerOptions),
+    (pane, pane, String),
+    (attribution, attribution, String)
+);
 
 impl LeafletEventHandler for Layer {
     fn on(&self, event: &str, callback: &JsValue) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ mod popup;
 mod raster;
 mod shapes;
 mod tooltip;
+mod util;
 
 use js_sys::Array;
 use paste::paste;
@@ -41,7 +42,7 @@ pub use handler::Handler;
 pub use icon::{Icon, IconOptions};
 pub use lat_lng::LatLng;
 pub use lat_lng_bounds::LatLngBounds;
-pub use layer::Layer;
+pub use layer::{Layer, LayerOptions};
 pub use layer_group::LayerGroup;
 pub use map::{
     DragEndEvent, ErrorEvent, LocateOptions, LocationEvent, Map, MapOptions, MouseEvent,
@@ -59,6 +60,7 @@ pub use shapes::{
     Rectangle,
 };
 pub use tooltip::{Tooltip, TooltipOptions};
+pub use util::Util;
 
 #[macro_export]
 macro_rules! object_property_set {
@@ -81,6 +83,86 @@ macro_rules! object_property_set {
                     &wasm_bindgen::JsValue::from(stringify!($b)),
                     &wasm_bindgen::JsValue::from(val),
                 );
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! create_object_with_properties {
+    (($t:ident, $t_js:ident), $(($rust:ident, $js:ident, $b:ty)),+) => {
+        $crate::paste! {
+            #[wasm_bindgen]
+            extern "C" {
+                #[wasm_bindgen (extends = Object , js_name = $t_js)]
+                #[derive(Debug, Clone, PartialEq, Eq)]
+                pub type $t;
+
+                $(
+                #[wasm_bindgen(method, getter, js_name = $js)]
+                pub fn $rust(this: &$t) -> $b;
+                )*
+
+                $(
+                #[wasm_bindgen(method, setter, js_name = $js)]
+                pub fn [<set_ $rust>](this: &$t, val: $b);
+                )*
+            }
+        }
+        impl $t {
+            #[allow(clippy::new_without_default)]
+            pub fn new() -> Self {
+                #[allow(unused_mut)]
+                let mut r = JsCast::unchecked_into(Object::new());
+                r
+            }
+        }
+    };
+    (($t:ident, $t_js:ident, $t_extends:ident), $(($rust:ident, $js:ident, $b:ty)),+) => {
+        $crate::paste! {
+            #[wasm_bindgen]
+            extern "C" {
+                #[wasm_bindgen(extends = $t_extends, js_name = $t_js)]
+                #[derive(Debug, Clone, PartialEq, Eq)]
+                pub type $t;
+
+                $(
+                #[wasm_bindgen(method, getter, js_name = $js)]
+                pub fn $rust(this: &$t) -> $b;
+                )*
+
+                $(
+                #[wasm_bindgen(method, setter, js_name = $js)]
+                pub fn [<set_ $rust>](this: &$t, val: $b);
+                )*
+            }
+        }
+        impl $t {
+            #[allow(clippy::new_without_default)]
+            pub fn new() -> Self {
+                #[allow(unused_mut)]
+                let mut r = JsCast::unchecked_into(Object::new());
+                r
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! add_object_properties {
+    ($t:ident, $(($rust:ident, $js:ident, $b:ty)),+) => {
+        $crate::paste! {
+            #[wasm_bindgen]
+            extern "C" {
+                $(
+                #[wasm_bindgen(method, getter, js_name = $js)]
+                pub fn $rust(this: &$t) -> $b;
+                )*
+
+                $(
+                #[wasm_bindgen(method, setter, js_name = $js)]
+                pub fn [<set_ $rust>](this: &$t, val: $b);
+                )*
             }
         }
     };

--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -8,7 +8,7 @@ use wasm_bindgen::prelude::*;
 use web_sys::HtmlElement;
 
 use crate::{
-    object_constructor, object_property_set, object_property_set_with, Control, Evented, LatLng,
+    create_object_with_properties, object_property_set_with, Control, Evented, LatLng,
     LatLngBounds, Layer, Point, Popup, Tooltip,
 };
 pub use events::*;
@@ -17,10 +17,6 @@ pub use location_event::*;
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(extends = Object , js_name = MapOptions)]
-    #[derive(Debug, Clone, Eq, PartialEq)]
-    pub type MapOptions;
-
     #[wasm_bindgen(extends=Evented)]
     #[derive(Debug, Clone)]
     pub type Map;
@@ -247,59 +243,65 @@ extern "C" {
 
     #[wasm_bindgen(method, js_name = latLngToLayerPoint)]
     pub fn lat_lng_to_layer_point(this: &Map, latlng: &LatLng) -> Point;
+
+    #[wasm_bindgen(method, js_name = getSize)]
+    pub fn get_size(this: &Map) -> Point;
 }
 
-impl MapOptions {
-    object_constructor!();
+create_object_with_properties!(
+    (MapOptions, MapOptions),
     // Options
-    object_property_set!(prefer_canvas, preferCanvas, bool);
+    (prefer_canvas, preferCanvas, bool),
     // Control options
-    object_property_set!(attribution_control, attributionControl, bool);
-    object_property_set!(zoom_control, zoomControl, bool);
+    (attribution_control, attributionControl, bool),
+    (zoom_control, zoomControl, bool),
     // Interaction Options
-    object_property_set!(close_popup_on_click, closePopupOnClick, bool);
-    object_property_set!(box_zoom, boxZoom, bool);
-    object_property_set!(double_click_zoom, doubleClickZoom, JsValue);
-    object_property_set!(dragging, bool);
-    object_property_set!(zoom_snap, zoomSnap, f64);
-    object_property_set!(zoom_delta, zoomDelta, f64);
-    object_property_set!(track_resize, trackResize, bool);
+    (close_popup_on_click, closePopupOnClick, bool),
+    (box_zoom, boxZoom, bool),
+    (double_click_zoom, doubleClickZoom, JsValue),
+    (dragging, dragging, bool),
+    (zoom_snap, zoomSnap, f64),
+    (zoom_delta, zoomDelta, f64),
+    (track_resize, trackResize, bool),
     // Panning Inertia Options
-    object_property_set!(inertia, bool);
-    object_property_set!(inertia_deceleration, inertiaDeceleration, f64);
-    object_property_set!(inertia_max_speed, inertiaMaxSpeed, f64);
-    object_property_set!(ease_linearity, easeLinearity, f64);
-    object_property_set!(world_copy_jump, worldCopyJump, bool);
-    object_property_set!(max_bounds_viscosity, maxBoundsViscosity, f64);
+    (inertia, inertia, bool),
+    (inertia_deceleration, inertiaDeceleration, f64),
+    (inertia_max_speed, inertiaMaxSpeed, f64),
+    (ease_linearity, easeLinearity, f64),
+    (world_copy_jump, worldCopyJump, bool),
+    (max_bounds_viscosity, maxBoundsViscosity, f64),
     // Keyboard Navigation Options
-    object_property_set!(keyboard, bool);
-    object_property_set!(keyboard_pan_delta, keyboardPanDelta, f64);
+    (keyboard, keyboard, bool),
+    (keyboard_pan_delta, keyboardPanDelta, f64),
     // Mouse wheel options
-    object_property_set!(scroll_wheel_zoom, scrollWheelZoom, bool);
-    object_property_set_with!(scroll_wheel_zoom_center, scrollWheelZoom, "center");
-    object_property_set!(wheel_debounce_time, wheelDebounceTime, f64);
-    object_property_set!(wheel_px_per_zoom_level, wheelPxPerZoomLevel, f64);
+    (scroll_wheel_zoom, scrollWheelZoom, bool),
+    (wheel_debounce_time, wheelDebounceTime, f64),
+    (wheel_px_per_zoom_level, wheelPxPerZoomLevel, f64),
     // Touch interaction options
-    object_property_set!(tap_hold, tapHold, bool);
-    object_property_set!(tap_tolerance, tapTolerance, f64);
-    object_property_set!(touch_zoom, touchZoom, bool);
-    object_property_set_with!(touch_zoom_center, touchZoom, "center");
-    object_property_set!(bounce_at_zoom_limits, bounceAtZoomLimits, bool);
+    (tap_hold, tapHold, bool),
+    (tap_tolerance, tapTolerance, f64),
+    (touch_zoom, touchZoom, bool),
+    (bounce_at_zoom_limits, bounceAtZoomLimits, bool),
     // Map State Options
-    object_property_set!(crs, &JsValue);
-    object_property_set!(center, &LatLng);
-    object_property_set!(zoom, f64);
-    object_property_set!(min_zoom, minZoom, f64);
-    object_property_set!(max_zoom, maxZoom, f64);
-    object_property_set!(layers, &Array);
-    object_property_set!(max_bounds, maxBounds, &LatLngBounds);
-    object_property_set!(renderer, &JsValue);
+    (crs, crs, JsValue),
+    (center, center, LatLng),
+    (zoom, zoom, f64),
+    (min_zoom, minZoom, f64),
+    (max_zoom, maxZoom, f64),
+    (layers, layers, Array),
+    (max_bounds, maxBounds, LatLngBounds),
+    (renderer, renderer, JsValue),
     // Animation Options
-    object_property_set!(zoom_animation, zoomAnimation, bool);
-    object_property_set!(zoom_animation_threshold, zoomAnimationThreshold, f64);
-    object_property_set!(fade_animation, fadeAnimation, bool);
-    object_property_set!(marker_zoom_animation, markerZoomAnimation, bool);
-    object_property_set!(transform3d_limit, transform3DLimit, f64);
+    (zoom_animation, zoomAnimation, bool),
+    (zoom_animation_threshold, zoomAnimationThreshold, f64),
+    (fade_animation, fadeAnimation, bool),
+    (marker_zoom_animation, markerZoomAnimation, bool),
+    (transform3d_limit, transform3DLimit, f64)
+);
+
+impl MapOptions {
+    object_property_set_with!(scroll_wheel_zoom_center, scrollWheelZoom, "center");
+    object_property_set_with!(touch_zoom_center, touchZoom, "center");
 }
 
 impl Default for MapOptions {

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -2,18 +2,13 @@ use crate::evented::{
     DragEvents, LeafletEventHandler, MouseEvents, MoveEvents, PopupEvents, TooltipEvents,
 };
 use crate::{
-    object_constructor, object_property_set, Evented, Handler, Icon, LatLng, Layer, LayerEvents,
-    Point,
+    create_object_with_properties, Evented, Handler, Icon, LatLng, Layer, LayerEvents, Point,
 };
 use js_sys::Object;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(extends = Object, js_name = MarkerOptions)]
-    #[derive(Debug, Clone)]
-    pub type MarkerOptions;
-
     // Marker
     #[derive(Debug, Clone, PartialEq)]
     #[wasm_bindgen(extends = Layer)]
@@ -54,46 +49,46 @@ extern "C" {
     pub fn set_z_index_offset(this: &Marker, offset: f64) -> Marker;
 }
 
-impl MarkerOptions {
-    object_constructor!();
+create_object_with_properties!(
+    (MarkerOptions, MarkerOptions),
     // [`icon`](https://leafletjs.com/reference.html#marker-icon)
-    object_property_set!(icon, Icon);
+    (icon, icon, Icon),
     // ['keyboard'](https://leafletjs.com/reference.html#marker-keyboard)
-    object_property_set!(keyboard, bool);
+    (keyboard, keyboard, bool),
     // ['title'](https://leafletjs.com/reference.html#marker-title)
-    object_property_set!(title, &str);
+    (title, title, String),
     // ['alt'](https://leafletjs.com/reference.html#marker-alt)
-    object_property_set!(alt, &str);
+    (alt, alt, String),
     // ['zIndexOffset'](https://leafletjs.com/reference.html#marker-zindexoffset)
-    object_property_set!(z_index_offset, zIndexOffset, f64);
+    (z_index_offset, zIndexOffset, f64),
     // ['opacity'](https://leafletjs.com/reference.html#marker-opacity)
-    object_property_set!(opacity, f64);
+    (opacity, opacity, f64),
     // ['riseOnHover'](https://leafletjs.com/reference.html#marker-riseonhover)
-    object_property_set!(rise_on_hover, riseOnHover, bool);
+    (rise_on_hover, riseOnHover, bool),
     // ['riseOffset'](https://leafletjs.com/reference.html#marker-riseoffset)
-    object_property_set!(rise_offset, riseOffset, f64);
+    (rise_offset, riseOffset, f64),
     // ['pane'](https://leafletjs.com/reference.html#marker-pane)
-    object_property_set!(pane, &str);
+    (pane, pane, String),
     // ['shadowPane'](https://leafletjs.com/reference.html#marker-shadowpane)
-    object_property_set!(shadow_pane, shadowPane, &str);
+    (shadow_pane, shadowPane, String),
     // ['bubblingMouseEvents'](https://leafletjs.com/reference.html#marker-bubblingmouseevents)
-    object_property_set!(bubbling_mouse_events, bubblingMouseEvents, bool);
+    (bubbling_mouse_events, bubblingMouseEvents, bool),
     // Draggable marker options
     // ['draggable'](https://leafletjs.com/reference.html#marker-draggable)
-    object_property_set!(draggable, bool);
+    (draggable, draggable, bool),
     // ['autoPan'](https://leafletjs.com/reference.html#marker-autopan)
-    object_property_set!(auto_pan, autoPan, bool);
+    (auto_pan, autoPan, bool),
     // ['autoPanPadding'](https://leafletjs.com/reference.html#marker-autopanpadding)
-    object_property_set!(auto_pan_padding, autoPanPadding, Point);
+    (auto_pan_padding, autoPanPadding, Point),
     // ['autoPanSpeed'](https://leafletjs.com/reference.html#marker-autopanspeed)
-    object_property_set!(auto_pan_speed, autoPanSpeed, f64);
+    (auto_pan_speed, autoPanSpeed, f64),
     // Interactive layer
     // ['interactive'](https://leafletjs.com/reference.html#marker-interactive)
-    object_property_set!(interactive, bool);
+    (interactive, interactive, bool),
     // Layer
     // ['attribution'](https://leafletjs.com/reference.html#marker-attribution)
-    object_property_set!(attribution, &str);
-}
+    (attribution, attribution, String)
+);
 
 impl Default for MarkerOptions {
     fn default() -> Self {

--- a/src/popup.rs
+++ b/src/popup.rs
@@ -1,16 +1,11 @@
 use js_sys::Object;
 use wasm_bindgen::prelude::*;
 
-use crate::{object_constructor, object_property_set, DivOverlay, LatLng, Layer, Point};
+use crate::{create_object_with_properties, DivOverlay, LatLng, Layer, Point};
 
 #[wasm_bindgen]
 extern "C" {
     // Popup
-
-    # [wasm_bindgen (extends = Object , js_name = PopupOptions)]
-    #[derive(Debug, Clone, PartialEq, Eq)]
-    pub type PopupOptions;
-
     /// [`Popup`](https://leafletjs.com/reference.html#popup)
     #[derive(Debug, Clone)]
     #[wasm_bindgen(extends = DivOverlay)]
@@ -25,28 +20,28 @@ extern "C" {
     pub fn new_with_lat_lng(lat_lng: &LatLng, options: &PopupOptions) -> Popup;
 }
 
-impl PopupOptions {
-    object_constructor!();
-    object_property_set!(pane, &str);
-    object_property_set!(offset, Point);
-    object_property_set!(min_width, minWidth, f64);
-    object_property_set!(max_width, maxWidth, f64);
-    object_property_set!(max_height, maxHeight, f64);
-    object_property_set!(auto_pan, autoPan, bool);
-    object_property_set!(auto_pan_padding_top_left, autoPanPaddingTopLeft, Point);
-    object_property_set!(
+create_object_with_properties!(
+    (PopupOptions, PopupOptions),
+    (pane, pane, String),
+    (offset, offset, Point),
+    (min_width, minWidth, f64),
+    (max_width, maxWidth, f64),
+    (max_height, maxHeight, f64),
+    (auto_pan, autoPan, bool),
+    (auto_pan_padding_top_left, autoPanPaddingTopLeft, Point),
+    (
         auto_pan_padding_bottom_right,
         autoPanPaddingBottomRight,
         Point
-    );
-    object_property_set!(auto_pan_padding, autoPanPadding, Point);
-    object_property_set!(keep_in_view, keepInView, bool);
-    object_property_set!(close_button, closeButton, bool);
-    object_property_set!(auto_close, autoClose, bool);
-    object_property_set!(close_on_escape_key, closeOnEscapeKey, bool);
-    object_property_set!(close_on_click, closeOnClick, bool);
-    object_property_set!(class_name, className, &str);
-}
+    ),
+    (auto_pan_padding, autoPanPadding, Point),
+    (keep_in_view, keepInView, bool),
+    (close_button, closeButton, bool),
+    (auto_close, autoClose, bool),
+    (close_on_escape_key, closeOnEscapeKey, bool),
+    (close_on_click, closeOnClick, bool),
+    (class_name, className, String)
+);
 
 impl Default for PopupOptions {
     fn default() -> Self {

--- a/src/raster/image_overlay.rs
+++ b/src/raster/image_overlay.rs
@@ -1,13 +1,9 @@
-﻿use crate::{object_constructor, object_property_set, LatLngBounds, Layer};
+﻿use crate::{create_object_with_properties, LatLngBounds, Layer};
 use js_sys::Object;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 extern "C" {
-    #[derive(Debug, Clone)]
-    #[wasm_bindgen(extends = Object, js_name = ImageOverlayOptions)]
-    pub type ImageOverlayOptions;
-
     #[wasm_bindgen(extends = Layer, js_name = ImageOverlay, js_namespace = L)]
     #[derive(Debug, Clone)]
     pub type ImageOverlay;
@@ -23,22 +19,22 @@ extern "C" {
     ) -> ImageOverlay;
 }
 
-impl ImageOverlayOptions {
-    object_constructor!();
-    object_property_set!(opacity, f64);
-    object_property_set!(alt, &str);
-    object_property_set!(interactive, bool);
-    object_property_set!(cross_origin, crossOrigin, &str);
-    object_property_set!(cross_origin_toggle, crossOrigin, bool);
-    object_property_set!(error_overlay_url, errorOverlayUrl, &str);
-    object_property_set!(z_index, zIndex, f64);
-    object_property_set!(class_name, className, &str);
+create_object_with_properties!(
+    (ImageOverlayOptions, ImageOverlayOptions),
+    (opacity, opacity, f64),
+    (alt, alt, String),
+    (interactive, interactive, bool),
+    (cross_origin, crossOrigin, String),
+    (cross_origin_toggle, crossOrigin, bool),
+    (error_overlay_url, errorOverlayUrl, String),
+    (z_index, zIndex, f64),
+    (class_name, className, String),
     // Interactive layer
-    object_property_set!(bubbling_mouse_events, bubblingMouseEvents, bool);
+    (bubbling_mouse_events, bubblingMouseEvents, bool),
     // Layer options
-    object_property_set!(pane, &str);
-    object_property_set!(attribution, &str);
-}
+    (pane, pane, String),
+    (attribution, attribution, String)
+);
 
 impl Default for ImageOverlayOptions {
     fn default() -> Self {

--- a/src/raster/tile_layer.rs
+++ b/src/raster/tile_layer.rs
@@ -2,15 +2,10 @@ use js_sys::{Function, Object};
 use wasm_bindgen::prelude::*;
 use web_sys::HtmlElement;
 
-use crate::{object_constructor, object_property_set, GridLayer, LatLng, LatLngBounds, Point};
+use crate::{create_object_with_properties, GridLayer, GridLayerOptions, LatLng};
 
 #[wasm_bindgen]
 extern "C" {
-
-    # [wasm_bindgen (extends = Object , js_name = TileLayerOptions)]
-    #[derive(Debug, Clone, PartialEq, Eq)]
-    #[wasm_bindgen(extends = GridLayer)]
-    pub type TileLayerOptions;
 
     #[derive(Debug, Clone, PartialEq)]
     #[wasm_bindgen(extends = GridLayer)]
@@ -24,6 +19,9 @@ extern "C" {
 
     #[wasm_bindgen(method, js_name = setUrl)]
     pub fn set_url(this: &TileLayer, url: &str, no_redraw: Option<bool>) -> TileLayer;
+
+    #[wasm_bindgen(method, getter, js_name = _url)]
+    pub fn url(this: &TileLayer) -> String;
 
     #[wasm_bindgen(method, js_name = getTileUrl)]
     pub fn get_tile_url(this: &TileLayer, coords: &LatLng) -> String;
@@ -39,37 +37,19 @@ extern "C" {
     ) -> HtmlElement;
 }
 
-impl TileLayerOptions {
-    object_constructor!();
-    // TileLayerOptions
-    object_property_set!(min_zoom, minZoom, f64);
-    object_property_set!(max_zoom, maxZoom, f64);
-    object_property_set!(subdomains, bool);
-    object_property_set!(error_tile_url, errorTileUrl, &str);
-    object_property_set!(zoom_offset, zoomOffset, f64);
-    object_property_set!(tms, bool);
-    object_property_set!(zoom_reverse, zoomReverse, bool);
-    object_property_set!(detect_retina, detectRetina, bool);
-    object_property_set!(cross_origin, crossOrigin, &str);
-    object_property_set!(referrer_policy, referrerPolicy, &str);
-    // GridLayerOptions
-    object_property_set!(tile_size, tileSize, u32);
-    object_property_set!(tile_size_with_point, tileSize, Point);
-    object_property_set!(opacity, opacity, f64);
-    object_property_set!(update_when_idle, updateWhenIdle, bool);
-    object_property_set!(update_when_zooming, updateWhenZooming, bool);
-    object_property_set!(update_interval, updateInterval, f64);
-    object_property_set!(z_index, zIndex, f64);
-    object_property_set!(bounds, bounds, LatLngBounds);
-    object_property_set!(max_native_zoom, maxNativeZoom, f64);
-    object_property_set!(min_native_zoom, minNativeZoom, f64);
-    object_property_set!(no_wrap, noWrap, bool);
-    object_property_set!(pane, &str);
-    object_property_set!(class_name, className, &str);
-    object_property_set!(keep_buffer, keepBuffer, u32);
-    // LayerOptions
-    object_property_set!(attribution, &str);
-}
+create_object_with_properties!(
+    (TileLayerOptions, TileLayerOptions, GridLayerOptions),
+    (min_zoom, minZoom, f64),
+    (max_zoom, maxZoom, f64),
+    (subdomains, subdomains, bool),
+    (error_tile_url, errorTileUrl, String),
+    (zoom_offset, zoomOffset, f64),
+    (tms, tms, bool),
+    (zoom_reverse, zoomReverse, bool),
+    (detect_retina, detectRetina, bool),
+    (cross_origin, crossOrigin, String),
+    (referrer_policy, referrerPolicy, String)
+);
 
 impl Default for TileLayerOptions {
     fn default() -> Self {

--- a/src/raster/video_overlay.rs
+++ b/src/raster/video_overlay.rs
@@ -1,13 +1,9 @@
-use crate::{object_constructor, object_property_set, ImageOverlay, LatLngBounds, Layer};
+use crate::{create_object_with_properties, ImageOverlay, LatLngBounds, Layer};
 use js_sys::Object;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 extern "C" {
-    #[derive(Debug, Clone)]
-    #[wasm_bindgen(extends = Object, js_name = ImageOverlayOptions)]
-    pub type VideoOverlayOptions;
-
     #[wasm_bindgen(extends = ImageOverlay, js_name = ImageOverlay, js_namespace = L)]
     #[derive(Debug, Clone)]
     pub type VideoOverlay;
@@ -23,27 +19,27 @@ extern "C" {
     ) -> VideoOverlay;
 }
 
-impl VideoOverlayOptions {
-    object_constructor!();
-    object_property_set!(opacity, f64);
-    object_property_set!(alt, &str);
-    object_property_set!(interactive, bool);
-    object_property_set!(cross_origin, crossOrigin, &str);
-    object_property_set!(cross_origin_toggle, crossOrigin, bool);
-    object_property_set!(error_overlay_url, errorOverlayUrl, &str);
-    object_property_set!(z_index, zIndex, f64);
-    object_property_set!(class_name, className, &str);
+create_object_with_properties!(
+    (VideoOverlayOptions, VideoOverlayOptions),
+    (opacity, opacity, f64),
+    (alt, alt, String),
+    (interactive, interactive, bool),
+    (cross_origin, crossOrigin, String),
+    (cross_origin_toggle, crossOrigin, bool),
+    (error_overlay_url, errorOverlayUrl, String),
+    (z_index, zIndex, f64),
+    (class_name, className, String),
     // Interactive layer
-    object_property_set!(bubbling_mouse_events, bubblingMouseEvents, bool);
+    (bubbling_mouse_events, bubblingMouseEvents, bool),
     // Layer options
-    object_property_set!(pane, &str);
-    object_property_set!(attribution, &str);
-    object_property_set!(autoplay, bool);
-    object_property_set!(looped, loop, bool);
-    object_property_set!(keep_aspect_ratio, keepAspectRatio, bool);
-    object_property_set!(muted, bool);
-    object_property_set!(plays_inline, playsInline, bool);
-}
+    (pane, pane, String),
+    (attribution, attribution, String),
+    (autoplay, autoplay, bool),
+    (looped, loop, bool),
+    (keep_aspect_ratio, keepAspectRatio, bool),
+    (muted, muted, bool),
+    (plays_inline, playsInline, bool)
+);
 
 impl Default for VideoOverlayOptions {
     fn default() -> Self {

--- a/src/shapes/circle.rs
+++ b/src/shapes/circle.rs
@@ -4,16 +4,12 @@ use wasm_bindgen::prelude::*;
 
 use crate::evented::{LeafletEventHandler, MouseEvents, MoveEvents, PopupEvents, TooltipEvents};
 use crate::{
-    object_constructor, object_property_set, CircleMarker, Evented, LatLng, LatLngBounds, Layer,
-    LayerEvents, PathOptions,
+    create_object_with_properties, CircleMarker, Evented, LatLng, LatLngBounds, Layer, LayerEvents,
+    PathOptions,
 };
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(extends = PathOptions, js_name = CircleOptions)]
-    #[derive(Debug, Clone, PartialEq)]
-    pub type CircleOptions;
-
     /// [`Circle`](https://leafletjs.com/reference.html#circle)
     #[derive(Debug, Clone)]
     #[wasm_bindgen(extends = CircleMarker)]
@@ -44,10 +40,10 @@ extern "C" {
     pub fn get_bounds(this: &Circle) -> LatLngBounds;
 }
 
-impl CircleOptions {
-    object_constructor!();
-    object_property_set!(radius, f64);
-}
+create_object_with_properties!(
+    (CircleOptions, CircleOptions, PathOptions),
+    (radius, radius, f64)
+);
 
 impl Default for CircleOptions {
     fn default() -> Self {

--- a/src/shapes/path.rs
+++ b/src/shapes/path.rs
@@ -1,15 +1,10 @@
 use js_sys::Object;
 use wasm_bindgen::prelude::*;
 
-use crate::{object_constructor, object_property_set, Layer};
+use crate::{create_object_with_properties, Layer};
 
 #[wasm_bindgen]
 extern "C" {
-
-    #[wasm_bindgen(extends = Object, js_name = PathOptions)]
-    #[derive(Debug, Clone, PartialEq)]
-    pub type PathOptions;
-
     /// [`Path`](https://leafletjs.com/reference.html#path)
     #[wasm_bindgen(extends = Layer)]
     #[derive(Debug, Clone)]
@@ -32,25 +27,25 @@ extern "C" {
     pub fn bring_to_back(this: &Path);
 }
 
-impl PathOptions {
-    object_constructor!();
-    object_property_set!(stroke, bool);
-    object_property_set!(color, &str);
-    object_property_set!(weight, f64);
-    object_property_set!(interactive, bool);
-    object_property_set!(opacity, f64);
-    object_property_set!(line_cap, lineCap, &str);
-    object_property_set!(line_join, lineJoin, &str);
-    object_property_set!(dash_array, dashArray, &str);
-    object_property_set!(dash_offset, dashOffset, &str);
-    object_property_set!(fill, bool);
-    object_property_set!(fill_color, fillColor, &str);
-    object_property_set!(fill_opacity, fillOpacity, f64);
-    object_property_set!(fill_rule, fillRule, &str);
-    object_property_set!(bubbling_mouse_events, bubblingMouseEvents, bool);
-    object_property_set!(renderer, &JsValue);
-    object_property_set!(class_name, className, &str);
-}
+create_object_with_properties!(
+    (PathOptions, PathOptions),
+    (stroke, stroke, bool),
+    (color, color, String),
+    (weight, weight, f64),
+    (interactive, interactive, bool),
+    (opacity, opacity, f64),
+    (line_cap, lineCap, String),
+    (line_join, lineJoin, String),
+    (dash_array, dashArray, String),
+    (dash_offset, dashOffset, String),
+    (fill, fill, bool),
+    (fill_color, fillColor, String),
+    (fill_opacity, fillOpacity, f64),
+    (fill_rule, fillRule, String),
+    (bubbling_mouse_events, bubblingMouseEvents, bool),
+    (renderer, renderer, JsValue),
+    (class_name, className, String)
+);
 
 impl Default for PathOptions {
     fn default() -> Self {

--- a/src/shapes/polyline.rs
+++ b/src/shapes/polyline.rs
@@ -5,17 +5,12 @@ use wasm_bindgen::prelude::*;
 
 use crate::evented::{LeafletEventHandler, MouseEvents, PopupEvents, TooltipEvents};
 use crate::{
-    object_constructor, object_property_set, Evented, LatLng, LatLngBounds, Layer, LayerEvents,
-    Path, PathOptions, Point,
+    create_object_with_properties, Evented, LatLng, LatLngBounds, Layer, LayerEvents, Path,
+    PathOptions, Point,
 };
 
 #[wasm_bindgen]
 extern "C" {
-
-    #[wasm_bindgen(extends = PathOptions, js_name = PolylineOptions)]
-    #[derive(Debug, Clone, PartialEq)]
-    pub type PolylineOptions;
-
     #[wasm_bindgen(extends = Path)]
     #[derive(Debug, Clone)]
     pub type Polyline;
@@ -51,11 +46,11 @@ extern "C" {
     pub fn add_lat_lng(this: &Polyline, lat_lng: &LatLng) -> Polyline;
 }
 
-impl PolylineOptions {
-    object_constructor!();
-    object_property_set!(smooth_factor, smoothFactor, f64);
-    object_property_set!(no_clip, noClip, bool);
-}
+create_object_with_properties!(
+    (PolylineOptions, PolylineOptions, PathOptions),
+    (smooth_factor, smoothFactor, f64),
+    (no_clip, noClip, bool)
+);
 
 impl Default for PolylineOptions {
     fn default() -> Self {

--- a/src/tooltip.rs
+++ b/src/tooltip.rs
@@ -1,14 +1,10 @@
 use js_sys::Object;
 use wasm_bindgen::prelude::*;
 
-use crate::{object_constructor, object_property_set, DivOverlay, LatLng, Layer, Point};
+use crate::{create_object_with_properties, DivOverlay, LatLng, Layer, Point};
 
 #[wasm_bindgen]
 extern "C" {
-    # [wasm_bindgen (extends = Object, js_name = PopupOptions)]
-    #[derive(Debug, Clone, PartialEq, Eq)]
-    pub type TooltipOptions;
-
     /// [`Tooltip`](https://leafletjs.com/reference-1.7.1.html#tooltip)
     #[derive(Debug, Clone)]
     #[wasm_bindgen(extends = DivOverlay)]
@@ -34,15 +30,15 @@ extern "C" {
     pub fn get_lat_lng(this: &Tooltip) -> LatLng;
 }
 
-impl TooltipOptions {
-    object_constructor!();
-    object_property_set!(pane, &str);
-    object_property_set!(direction, &str);
-    object_property_set!(offset, &Point);
-    object_property_set!(permanent, bool);
-    object_property_set!(sticky, bool);
-    object_property_set!(opacity, f64);
-}
+create_object_with_properties!(
+    (TooltipOptions, TooltipOptions),
+    (pane, pane, String),
+    (direction, direction, String),
+    (offset, offset, Point),
+    (permanent, permanent, bool),
+    (sticky, sticky, bool),
+    (opacity, opacity, f64)
+);
 
 impl Default for TooltipOptions {
     fn default() -> Self {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,34 @@
+//! L.Util bindings.
+
+use js_sys::Object;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = ["L", "Util"], js_name = "getParamString")]
+    fn get_param_string(params: Object) -> String;
+
+    #[wasm_bindgen(js_namespace = ["L", "Util"], js_name = "getParamString")]
+    fn get_param_string_url(params: Object, url: &str) -> String;
+
+    #[wasm_bindgen(js_namespace = ["L", "Util"], js_name = "getParamString")]
+    fn get_param_string_url_uppercase(params: Object, url: &str, uppercase: bool) -> String;
+}
+
+/// The `L.Util` namespace.
+pub struct Util;
+
+impl Util {
+    /// [`getParamString`](https://leafletjs.com/reference.html#util-getparamstring).
+    pub fn get_param_string(params: Object) -> String {
+        get_param_string(params)
+    }
+    /// [`getParamString`](https://leafletjs.com/reference.html#util-getparamstring).
+    pub fn get_param_string_url(params: Object, url: &str) -> String {
+        get_param_string_url(params, url)
+    }
+    /// [`getParamString`](https://leafletjs.com/reference.html#util-getparamstring).
+    pub fn get_param_string_url_uppercase(params: Object, url: &str, uppercase: bool) -> String {
+        get_param_string_url_uppercase(params, url, uppercase)
+    }
+}


### PR DESCRIPTION
This PR introduces a new macro `create_object_with_properties` that generates a constructor, getter and setter for each property of the given object and offers the possibility to extend the new object from another one. This leads to less repetitions in the options definitions. The drawback here is that it is not yet possible to return a reference with `wasm_bindgen`, leading to owned parameter and return values in all generated methods.

It also adds the `TileLayerWms::get_feature_info_url` which is required to request feature infos from a `WMS` service.

I am open to discussions and changes if required.