### PR TITLE
fix: add missing FeatureGroup constructor

### DIFF
--- a/src/feature_group.rs
+++ b/src/feature_group.rs
@@ -9,6 +9,9 @@ extern "C" {
     #[wasm_bindgen(extends = LayerGroup)]
     pub type FeatureGroup;
 
+    #[wasm_bindgen(constructor, js_namespace = L)]
+    pub fn new() -> FeatureGroup;
+
     /// [`setStyle`](https://leafletjs.com/reference-1.7.1.html#featuregroup-setstyle)
     #[wasm_bindgen(method, js_name = "setStyle")]
     pub fn set_style(this: &FeatureGroup, style: &JsValue);


### PR DESCRIPTION
This PR adds a `new()` method to `FeatureGroup` to be able to construct one. Fixes #28.