### PR TITLE
Add new builder for `LatLngBounds`

### DIFF
--- a/src/lat_lng_bounds.rs
+++ b/src/lat_lng_bounds.rs
@@ -1,6 +1,6 @@
 use wasm_bindgen::prelude::*;
 
-use crate::LatLng;
+use crate::{Array, LatLng};
 
 #[wasm_bindgen]
 extern "C" {
@@ -10,8 +10,23 @@ extern "C" {
     #[wasm_bindgen(constructor, js_namespace = L)]
     pub fn new(corner1: &LatLng, corner2: &LatLng) -> LatLngBounds;
 
+    #[wasm_bindgen(constructor, js_namespace = L)]
+    pub fn new_from_list(positions: &Array) -> LatLngBounds;
+
+    #[wasm_bindgen(method, js_namespace = L)]
+    pub fn extend(this: &LatLngBounds, latlng: &LatLng) -> LatLngBounds;
+
+    #[wasm_bindgen(method, js_namespace = L, js_name = extend)]
+    pub fn extend_with_bounds(this: &LatLngBounds, bounds: &LatLngBounds) -> LatLngBounds;
+
     #[wasm_bindgen(method, js_name = getNorthEast)]
     pub fn get_north_east(this: &LatLngBounds) -> LatLng;
+
+    #[wasm_bindgen(method, js_name = getNorthWest)]
+    pub fn get_north_west(this: &LatLngBounds) -> LatLng;
+
+    #[wasm_bindgen(method, js_name = getSouthEast)]
+    pub fn get_south_east(this: &LatLngBounds) -> LatLng;
 
     #[wasm_bindgen(method, js_name = getSouthWest)]
     pub fn get_south_west(this: &LatLngBounds) -> LatLng;


### PR DESCRIPTION
Add bounds construction from a list of positions and support for the `extend` method. 

[Doc](https://leafletjs.com/reference.html#latlngbounds)