### PR TITLE
Allow error processing in Map constructor

### DIFF
--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -21,11 +21,11 @@ extern "C" {
     #[derive(Debug, Clone)]
     pub type Map;
 
-    #[wasm_bindgen(constructor, js_namespace = L)]
-    pub fn new(id: &str, options: &MapOptions) -> Map;
+    #[wasm_bindgen(constructor, js_namespace = L, catch)]
+    pub fn new(id: &str, options: &MapOptions) -> Result<Map, JsValue>;
 
-    #[wasm_bindgen(constructor, js_namespace = L)]
-    pub fn new_with_element(el: &HtmlElement, options: &MapOptions) -> Map;
+    #[wasm_bindgen(constructor, js_namespace = L, catch)]
+    pub fn new_with_element(el: &HtmlElement, options: &MapOptions) -> Result<Map, JsValue>;
 
     // Methods for Layers and Controls
     #[wasm_bindgen(method, js_name = addControl)]


### PR DESCRIPTION
Tweaks constructor definition to allow catching errors. The current definition on master crashes the whole process on error. Easiest way to test this is to run offline, error happens out of rust's control.